### PR TITLE
CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ So here are relevant portions of our app, you can look at the history of the app
 }
 ```
 
-But, when I try to build...
-**22 Errors break the builds**
-![Aug-16-2019 14-56-18-2](https://user-images.githubusercontent.com/1245512/63197804-08ce1000-c036-11e9-823b-dc11a140b683.gif)
+But, when I try to build... **22 Errors break the builds**
+
+![Aug-19-2019 16-50-15](https://user-images.githubusercontent.com/1245512/63304782-80ec3e00-c2a1-11e9-9cb9-72909522a76d.gif)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Sample Minimum Repo to Reproduce Pusher Push Notifications Issue
+
+So our company has used RNPusherPushNotifications for over a year in our RN app. This last week I started the upgrade to [RN 0.60.x](https://facebook.github.io/react-native/blog/2019/07/03/version-60) but I have been blocked by this package for the last couple days. Would really appreciate help.
+
+So here are relevant portions of our app, you can look at the history of the app as well:
+
+**package.json**
+```
+"dependencies": {
+"react-native-pusher-push-notifications": "git+http://git@github.com/ZeptInc/react-native-pusher-push-notifications#v.2.4.1-zept-master",
+}
+```
+
+But, when I try to build...
+**22 Errors break the builds**
+![Aug-16-2019 14-56-18-2](https://user-images.githubusercontent.com/1245512/63197804-08ce1000-c036-11e9-823b-dc11a140b683.gif)

--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ So here are relevant portions of our app, you can look at the history of the app
 But, when I try to build... **22 Errors break the builds**
 
 ![Aug-19-2019 16-50-15](https://user-images.githubusercontent.com/1245512/63304782-80ec3e00-c2a1-11e9-9cb9-72909522a76d.gif)
+
+
+## Relevant Links
+- https://github.com/b8ne/react-native-pusher-push-notifications
+- https://github.com/pusher/push-notifications-swift

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,5 @@
-platform :ios, '9.0'
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '10.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 target 'Rn60TestPusherPushNotifications' do
@@ -26,6 +27,9 @@ target 'Rn60TestPusherPushNotifications' do
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+
+
+  pod 'PushNotifications', '~> 2.1.2'
 
   target 'Rn60TestPusherPushNotificationsTests' do
     inherit! :search_paths

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,6 +11,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
+  - PushNotifications (2.1.2)
   - React (0.60.5):
     - React-Core (= 0.60.5)
     - React-DevSupport (= 0.60.5)
@@ -85,6 +86,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - PushNotifications (~> 2.1.2)
   - React (from `../node_modules/react-native/`)
   - React-Core (from `../node_modules/react-native/React`)
   - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
@@ -107,6 +109,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - boost-for-react-native
+    - PushNotifications
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -157,6 +160,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  PushNotifications: 3d1ac73f4e1e9dc3de8fa8319e3e53bd00be47dc
   React: 53c53c4d99097af47cf60594b8706b4e3321e722
   React-Core: ba421f6b4f4cbe2fb17c0b6fc675f87622e78a64
   React-cxxreact: 8384287780c4999351ad9b6e7a149d9ed10a2395
@@ -176,6 +180,6 @@ SPEC CHECKSUMS:
   React-RCTWebSocket: cd932a16b7214898b6b7f788c8bddb3637246ac4
   yoga: 312528f5bbbba37b4dcea5ef00e8b4033fdd9411
 
-PODFILE CHECKSUM: 9b6b3a4e2d354a4a976b4726909b5cb470402963
+PODFILE CHECKSUM: 79562f61ab621e69cf42f214f9cc1920fea888d9
 
 COCOAPODS: 1.7.4

--- a/ios/Rn60TestPusherPushNotifications-Bridging-Header.h
+++ b/ios/Rn60TestPusherPushNotifications-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/ios/Rn60TestPusherPushNotifications.xcodeproj/project.pbxproj
+++ b/ios/Rn60TestPusherPushNotifications.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		2D02E4901E0B4A5D006451C7 /* Rn60TestPusherPushNotifications-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Rn60TestPusherPushNotifications-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		41FC6F3A4EEDBA27A637D6D3 /* libPods-Rn60TestPusherPushNotificationsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Rn60TestPusherPushNotificationsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNPusherPushNotifications.xcodeproj; path = "../node_modules/react-native-pusher-push-notifications/ios/RNPusherPushNotifications.xcodeproj"; sourceTree = "<group>"; };
+		49F3F215230B5C4B00537BA3 /* Rn60TestPusherPushNotifications-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Rn60TestPusherPushNotifications-Bridging-Header.h"; sourceTree = "<group>"; };
 		6787B26E8E3A4A7CFE01D3E7 /* Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Rn60TestPusherPushNotifications-tvOSTests/Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		6D8B67C8F4811143658247CA /* Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rn60TestPusherPushNotifications-tvOS/Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		7F8778C8D86E835843781600 /* libPods-Rn60TestPusherPushNotifications.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Rn60TestPusherPushNotifications.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -142,6 +143,7 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				49F3F215230B5C4B00537BA3 /* Rn60TestPusherPushNotifications-Bridging-Header.h */,
 			);
 			name = Rn60TestPusherPushNotifications;
 			sourceTree = "<group>";
@@ -309,6 +311,9 @@
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
+					};
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1030;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -661,6 +666,7 @@
 			baseConfigurationReference = A1284157433A2A8B140F66EB /* Pods-Rn60TestPusherPushNotifications.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				INFOPLIST_FILE = Rn60TestPusherPushNotifications/Info.plist;
@@ -672,6 +678,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Rn60TestPusherPushNotifications;
+				SWIFT_OBJC_BRIDGING_HEADER = "Rn60TestPusherPushNotifications-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -681,6 +690,7 @@
 			baseConfigurationReference = A1438C07CB7CA67610F2BFD2 /* Pods-Rn60TestPusherPushNotifications.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = Rn60TestPusherPushNotifications/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -691,6 +701,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Rn60TestPusherPushNotifications;
+				SWIFT_OBJC_BRIDGING_HEADER = "Rn60TestPusherPushNotifications-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/ios/Rn60TestPusherPushNotifications.xcodeproj/project.pbxproj
+++ b/ios/Rn60TestPusherPushNotifications.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* Rn60TestPusherPushNotificationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* Rn60TestPusherPushNotificationsTests.m */; };
 		460ED655C4D4EC3A26E5D847 /* libPods-Rn60TestPusherPushNotifications-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C45A1CAE5D1263B60DE8BF98 /* libPods-Rn60TestPusherPushNotifications-tvOSTests.a */; };
+		49F3F210230B585100537BA3 /* libRNPusherPushNotifications.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 49F3F20F230B583700537BA3 /* libRNPusherPushNotifications.a */; };
 		59E72B3C846B09C6241B1C57 /* libPods-Rn60TestPusherPushNotifications-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C78ED333472E2849BF5E78E6 /* libPods-Rn60TestPusherPushNotifications-tvOS.a */; };
 		A600A19069A6376E4D59FCB8 /* libPods-Rn60TestPusherPushNotifications.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F8778C8D86E835843781600 /* libPods-Rn60TestPusherPushNotifications.a */; };
 /* End PBXBuildFile section */
@@ -37,6 +38,13 @@
 			remoteGlobalIDString = 2D02E47A1E0B4A5D006451C7;
 			remoteInfo = "Rn60TestPusherPushNotifications-tvOS";
 		};
+		49F3F20E230B583700537BA3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNPusherPushNotifications;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +62,7 @@
 		2D02E47B1E0B4A5D006451C7 /* Rn60TestPusherPushNotifications-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Rn60TestPusherPushNotifications-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* Rn60TestPusherPushNotifications-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Rn60TestPusherPushNotifications-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		41FC6F3A4EEDBA27A637D6D3 /* libPods-Rn60TestPusherPushNotificationsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Rn60TestPusherPushNotificationsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNPusherPushNotifications.xcodeproj; path = "../node_modules/react-native-pusher-push-notifications/ios/RNPusherPushNotifications.xcodeproj"; sourceTree = "<group>"; };
 		6787B26E8E3A4A7CFE01D3E7 /* Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Rn60TestPusherPushNotifications-tvOSTests/Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		6D8B67C8F4811143658247CA /* Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rn60TestPusherPushNotifications-tvOS/Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		7F8778C8D86E835843781600 /* libPods-Rn60TestPusherPushNotifications.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Rn60TestPusherPushNotifications.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,6 +92,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A600A19069A6376E4D59FCB8 /* libPods-Rn60TestPusherPushNotifications.a in Frameworks */,
+				49F3F210230B585100537BA3 /* libRNPusherPushNotifications.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,9 +159,18 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		49F3F20B230B583700537BA3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				49F3F20F230B583700537BA3 /* libRNPusherPushNotifications.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -194,7 +213,6 @@
 				9C0CD99899912E264E23785E /* Pods-Rn60TestPusherPushNotificationsTests.debug.xcconfig */,
 				C33C89FE1CD7F0E886112D49 /* Pods-Rn60TestPusherPushNotificationsTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -308,12 +326,19 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 49F3F20B230B583700537BA3 /* Products */;
+					ProjectRef = 49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* Rn60TestPusherPushNotifications */,
@@ -323,6 +348,16 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		49F3F20F230B583700537BA3 /* libRNPusherPushNotifications.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNPusherPushNotifications.a;
+			remoteRef = 49F3F20E230B583700537BA3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		00E356EC1AD99517003FC87E /* Resources */ = {

--- a/ios/Rn60TestPusherPushNotifications/AppDelegate.m
+++ b/ios/Rn60TestPusherPushNotifications/AppDelegate.m
@@ -10,6 +10,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <RNPusherPushNotifications.h>
 
 @implementation AppDelegate
 
@@ -37,6 +38,19 @@
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
+}
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+  NSLog(@"Registered for remote with token: %@", deviceToken);
+  [[RNPusherPushNotifications alloc] setDeviceToken:deviceToken];
+}
+
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+  [[RNPusherPushNotifications alloc] handleNotification:userInfo];
+}
+
+-(void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+  NSLog(@"Remote notification support is unavailable due to error: %@", error.localizedDescription);
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "0.60.5"
+    "react-native": "0.60.5",
+    "react-native-pusher-push-notifications": "git+http://git@github.com/ZeptInc/react-native-pusher-push-notifications#v.2.4.1-zept-master"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5200,6 +5200,11 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
+react-native-pusher-push-notifications@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-pusher-push-notifications/-/react-native-pusher-push-notifications-2.1.0.tgz#2b24b02273116306234eee6a0c79779895dde985"
+  integrity sha512-MsGVArGg+O7Bkc4bVDBKTrnIJnMHSgqFDFPVKnPiyzvhIH9FlYlx4C9b0wqlX+4cgeaSkJ1SWpzWcnCpdv7dfA==
+
 react-native@0.60.5:
   version "0.60.5"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.60.5.tgz#3c1d9c06a0fbab9807220b6acac09488d39186ee"


### PR DESCRIPTION
# Sample Minimum Repo to Reproduce Pusher Push Notifications Issue

So our company has used RNPusherPushNotifications for over a year in our RN app. This last week I started the upgrade to [RN 0.60.x](https://facebook.github.io/react-native/blog/2019/07/03/version-60) but I have been blocked by this package for the last couple days. Would really appreciate help.

So here are relevant portions of our app, you can look at the history of the app as well:

**package.json**
```
"dependencies": {
"react-native-pusher-push-notifications": "git+http://git@github.com/ZeptInc/react-native-pusher-push-notifications#v.2.4.1-zept-master",
}
```

But, when I try to build... **22 Errors break the builds**

![Aug-19-2019 16-50-15](https://user-images.githubusercontent.com/1245512/63304782-80ec3e00-c2a1-11e9-9cb9-72909522a76d.gif)


## Relevant Links
- https://github.com/b8ne/react-native-pusher-push-notifications
- https://github.com/pusher/push-notifications-swift
