### PR TITLE
Carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ buck-out/
 
 # CocoaPods
 /ios/Pods/
+/ios/Carthage

--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ So here are relevant portions of our app, you can look at the history of the app
 But, when I try to build... **22 Errors break the builds**
 
 ![Aug-19-2019 16-50-15](https://user-images.githubusercontent.com/1245512/63304782-80ec3e00-c2a1-11e9-9cb9-72909522a76d.gif)
+
+
+## Relevant Links
+- https://github.com/b8ne/react-native-pusher-push-notifications
+- https://github.com/pusher/push-notifications-swift

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Sample Minimum Repo to Reproduce Pusher Push Notifications Issue
+
+So our company has used RNPusherPushNotifications for over a year in our RN app. This last week I started the upgrade to [RN 0.60.x](https://facebook.github.io/react-native/blog/2019/07/03/version-60) but I have been blocked by this package for the last couple days. Would really appreciate help.
+
+So here are relevant portions of our app, you can look at the history of the app as well:
+
+**package.json**
+```
+"dependencies": {
+"react-native-pusher-push-notifications": "git+http://git@github.com/ZeptInc/react-native-pusher-push-notifications#v.2.4.1-zept-master",
+}
+```
+
+But, when I try to build... **22 Errors break the builds**
+
+![Aug-19-2019 16-50-15](https://user-images.githubusercontent.com/1245512/63304782-80ec3e00-c2a1-11e9-9cb9-72909522a76d.gif)

--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,0 +1,1 @@
+github "pusher/push-notifications-swift"

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "pusher/push-notifications-swift" "2.1.2"

--- a/ios/Rn60TestPusherPushNotifications.xcodeproj/project.pbxproj
+++ b/ios/Rn60TestPusherPushNotifications.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* Rn60TestPusherPushNotificationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* Rn60TestPusherPushNotificationsTests.m */; };
 		460ED655C4D4EC3A26E5D847 /* libPods-Rn60TestPusherPushNotifications-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C45A1CAE5D1263B60DE8BF98 /* libPods-Rn60TestPusherPushNotifications-tvOSTests.a */; };
+		49F3F210230B585100537BA3 /* libRNPusherPushNotifications.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 49F3F20F230B583700537BA3 /* libRNPusherPushNotifications.a */; };
 		59E72B3C846B09C6241B1C57 /* libPods-Rn60TestPusherPushNotifications-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C78ED333472E2849BF5E78E6 /* libPods-Rn60TestPusherPushNotifications-tvOS.a */; };
 		A600A19069A6376E4D59FCB8 /* libPods-Rn60TestPusherPushNotifications.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F8778C8D86E835843781600 /* libPods-Rn60TestPusherPushNotifications.a */; };
 /* End PBXBuildFile section */
@@ -37,6 +38,13 @@
 			remoteGlobalIDString = 2D02E47A1E0B4A5D006451C7;
 			remoteInfo = "Rn60TestPusherPushNotifications-tvOS";
 		};
+		49F3F20E230B583700537BA3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNPusherPushNotifications;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +62,7 @@
 		2D02E47B1E0B4A5D006451C7 /* Rn60TestPusherPushNotifications-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Rn60TestPusherPushNotifications-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* Rn60TestPusherPushNotifications-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Rn60TestPusherPushNotifications-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		41FC6F3A4EEDBA27A637D6D3 /* libPods-Rn60TestPusherPushNotificationsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Rn60TestPusherPushNotificationsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNPusherPushNotifications.xcodeproj; path = "../node_modules/react-native-pusher-push-notifications/ios/RNPusherPushNotifications.xcodeproj"; sourceTree = "<group>"; };
 		6787B26E8E3A4A7CFE01D3E7 /* Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Rn60TestPusherPushNotifications-tvOSTests/Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		6D8B67C8F4811143658247CA /* Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rn60TestPusherPushNotifications-tvOS/Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		7F8778C8D86E835843781600 /* libPods-Rn60TestPusherPushNotifications.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Rn60TestPusherPushNotifications.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,6 +92,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A600A19069A6376E4D59FCB8 /* libPods-Rn60TestPusherPushNotifications.a in Frameworks */,
+				49F3F210230B585100537BA3 /* libRNPusherPushNotifications.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,9 +159,18 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		49F3F20B230B583700537BA3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				49F3F20F230B583700537BA3 /* libRNPusherPushNotifications.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -194,7 +213,6 @@
 				9C0CD99899912E264E23785E /* Pods-Rn60TestPusherPushNotificationsTests.debug.xcconfig */,
 				C33C89FE1CD7F0E886112D49 /* Pods-Rn60TestPusherPushNotificationsTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -308,12 +326,19 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 49F3F20B230B583700537BA3 /* Products */;
+					ProjectRef = 49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* Rn60TestPusherPushNotifications */,
@@ -323,6 +348,16 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		49F3F20F230B583700537BA3 /* libRNPusherPushNotifications.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNPusherPushNotifications.a;
+			remoteRef = 49F3F20E230B583700537BA3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		00E356EC1AD99517003FC87E /* Resources */ = {

--- a/ios/Rn60TestPusherPushNotifications.xcodeproj/project.pbxproj
+++ b/ios/Rn60TestPusherPushNotifications.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -19,6 +19,7 @@
 		2DCD954D1E0B4F2C00145EB5 /* Rn60TestPusherPushNotificationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* Rn60TestPusherPushNotificationsTests.m */; };
 		460ED655C4D4EC3A26E5D847 /* libPods-Rn60TestPusherPushNotifications-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C45A1CAE5D1263B60DE8BF98 /* libPods-Rn60TestPusherPushNotifications-tvOSTests.a */; };
 		49F3F210230B585100537BA3 /* libRNPusherPushNotifications.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 49F3F20F230B583700537BA3 /* libRNPusherPushNotifications.a */; };
+		49F3F212230B59BE00537BA3 /* PushNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49F3F211230B59BE00537BA3 /* PushNotifications.framework */; };
 		59E72B3C846B09C6241B1C57 /* libPods-Rn60TestPusherPushNotifications-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C78ED333472E2849BF5E78E6 /* libPods-Rn60TestPusherPushNotifications-tvOS.a */; };
 		A600A19069A6376E4D59FCB8 /* libPods-Rn60TestPusherPushNotifications.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F8778C8D86E835843781600 /* libPods-Rn60TestPusherPushNotifications.a */; };
 /* End PBXBuildFile section */
@@ -63,6 +64,7 @@
 		2D02E4901E0B4A5D006451C7 /* Rn60TestPusherPushNotifications-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Rn60TestPusherPushNotifications-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		41FC6F3A4EEDBA27A637D6D3 /* libPods-Rn60TestPusherPushNotificationsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Rn60TestPusherPushNotificationsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49F3F20A230B583700537BA3 /* RNPusherPushNotifications.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNPusherPushNotifications.xcodeproj; path = "../node_modules/react-native-pusher-push-notifications/ios/RNPusherPushNotifications.xcodeproj"; sourceTree = "<group>"; };
+		49F3F211230B59BE00537BA3 /* PushNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PushNotifications.framework; path = Carthage/Build/iOS/PushNotifications.framework; sourceTree = "<group>"; };
 		6787B26E8E3A4A7CFE01D3E7 /* Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Rn60TestPusherPushNotifications-tvOSTests/Pods-Rn60TestPusherPushNotifications-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		6D8B67C8F4811143658247CA /* Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rn60TestPusherPushNotifications-tvOS/Pods-Rn60TestPusherPushNotifications-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		7F8778C8D86E835843781600 /* libPods-Rn60TestPusherPushNotifications.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Rn60TestPusherPushNotifications.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -93,6 +95,7 @@
 			files = (
 				A600A19069A6376E4D59FCB8 /* libPods-Rn60TestPusherPushNotifications.a in Frameworks */,
 				49F3F210230B585100537BA3 /* libRNPusherPushNotifications.a in Frameworks */,
+				49F3F212230B59BE00537BA3 /* PushNotifications.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,6 +152,7 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				49F3F211230B59BE00537BA3 /* PushNotifications.framework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
 				7F8778C8D86E835843781600 /* libPods-Rn60TestPusherPushNotifications.a */,
@@ -248,6 +252,7 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				49F3F213230B59D900537BA3 /* Carthage Script */,
 			);
 			buildRules = (
 			);
@@ -303,7 +308,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
@@ -443,6 +448,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+		};
+		49F3F213230B59D900537BA3 /* Carthage Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(SRCROOT)/input.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Carthage Script";
+			outputFileListPaths = (
+				"$(SRCROOT)/output.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		A4A1FE463389B85BE78D104E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -624,7 +649,11 @@
 				);
 				INFOPLIST_FILE = Rn60TestPusherPushNotificationsTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -644,7 +673,11 @@
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = Rn60TestPusherPushNotificationsTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -663,8 +696,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Rn60TestPusherPushNotifications/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -682,8 +722,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Rn60TestPusherPushNotifications/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -709,7 +756,10 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Rn60TestPusherPushNotifications-tvOS/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -737,7 +787,10 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Rn60TestPusherPushNotifications-tvOS/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -764,7 +817,11 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Rn60TestPusherPushNotifications-tvOSTests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -791,7 +848,11 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Rn60TestPusherPushNotifications-tvOSTests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -809,6 +870,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -862,6 +924,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/ios/Rn60TestPusherPushNotifications.xcodeproj/xcshareddata/xcschemes/Rn60TestPusherPushNotifications-tvOS.xcscheme
+++ b/ios/Rn60TestPusherPushNotifications.xcodeproj/xcshareddata/xcschemes/Rn60TestPusherPushNotifications-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/ios/Rn60TestPusherPushNotifications.xcodeproj/xcshareddata/xcschemes/Rn60TestPusherPushNotifications.xcscheme
+++ b/ios/Rn60TestPusherPushNotifications.xcodeproj/xcshareddata/xcschemes/Rn60TestPusherPushNotifications.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/ios/Rn60TestPusherPushNotifications/AppDelegate.m
+++ b/ios/Rn60TestPusherPushNotifications/AppDelegate.m
@@ -10,6 +10,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <RNPusherPushNotifications.h>
 
 @implementation AppDelegate
 
@@ -37,6 +38,19 @@
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
+}
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+  NSLog(@"Registered for remote with token: %@", deviceToken);
+  [[RNPusherPushNotifications alloc] setDeviceToken:deviceToken];
+}
+
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+  [[RNPusherPushNotifications alloc] handleNotification:userInfo];
+}
+
+-(void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+  NSLog(@"Remote notification support is unavailable due to error: %@", error.localizedDescription);
 }
 
 @end

--- a/ios/input.xcfilelist
+++ b/ios/input.xcfilelist
@@ -1,0 +1,1 @@
+$(SRCROOT)/Carthage/Build/iOS/PushNotifications.framework

--- a/ios/output.xcfilelist
+++ b/ios/output.xcfilelist
@@ -1,0 +1,1 @@
+$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/PushNotifications.framework

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "0.60.5"
+    "react-native": "0.60.5",
+    "react-native-pusher-push-notifications": "git+http://git@github.com/ZeptInc/react-native-pusher-push-notifications#v.2.4.1-zept-master"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5200,6 +5200,11 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
+react-native-pusher-push-notifications@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-pusher-push-notifications/-/react-native-pusher-push-notifications-2.1.0.tgz#2b24b02273116306234eee6a0c79779895dde985"
+  integrity sha512-MsGVArGg+O7Bkc4bVDBKTrnIJnMHSgqFDFPVKnPiyzvhIH9FlYlx4C9b0wqlX+4cgeaSkJ1SWpzWcnCpdv7dfA==
+
 react-native@0.60.5:
   version "0.60.5"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.60.5.tgz#3c1d9c06a0fbab9807220b6acac09488d39186ee"


### PR DESCRIPTION
# Sample Minimum Repo to Reproduce Pusher Push Notifications Issue

So our company has used RNPusherPushNotifications for over a year in our RN app. This last week I started the upgrade to [RN 0.60.x](https://facebook.github.io/react-native/blog/2019/07/03/version-60) but I have been blocked by this package for the last couple days. Would really appreciate help.

So here are relevant portions of our app, you can look at the history of the app as well:

**package.json**
```
"dependencies": {
"react-native-pusher-push-notifications": "git+http://git@github.com/ZeptInc/react-native-pusher-push-notifications#v.2.4.1-zept-master",
}
```

But, when I try to build... **22 Errors break the builds**

![Aug-19-2019 16-50-15](https://user-images.githubusercontent.com/1245512/63304782-80ec3e00-c2a1-11e9-9cb9-72909522a76d.gif)


## Relevant Links
- https://github.com/b8ne/react-native-pusher-push-notifications
- https://github.com/pusher/push-notifications-swift
